### PR TITLE
Add deck validator, docs migration guide, and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,23 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint
+      - name: Validate changed Markdown decks (non-blocking)
+        run: |
+          set -e
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE_SHA" ]; then BASE_SHA="${{ github.sha }}~1"; fi
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD | grep -E '\\.(md|markdown)$' || true)
+          if [ -z "$CHANGED" ]; then echo "No changed markdown files"; exit 0; fi
+          echo "Validating:\n$CHANGED"
+          OK=0
+          for f in $CHANGED; do
+            if [ -f "$f" ]; then
+              echo "-- $f"
+              # Do not fail CI for warnings yet; print and continue
+              node dev-tools/validate-deck.js "$f" || OK=1
+            fi
+          done
+          exit 0
 
   unit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ What to try
 - The app loads `sample_presentation.md` automatically on first run.
 - Click the top toolbar "Load Markdown" button (📁) and choose a Markdown file to load your slides.
 - Navigate with ← / → keys or on-screen arrows; thumbnails appear in the left drawer.
+- Validate your deck: Click “Validate” in the header to check frontmatter keys and values. Or run `npm run validate:deck -- path/to/deck.md` locally to lint Markdown decks in CI or pre-commit.
 - Useful keys:
   - B — cycle background modes (Particles → Gradient → Off)
   - T — toggle slide transparency (0% ↔ baseline)
@@ -89,6 +90,13 @@ Then run E2E:
 npm run test:e2e
 # or run all tests
 npm run test:all
+
+- Validate decks (authoring aid):
+
+```bash
+npm run validate:deck -- sample_presentation.md
+```
+Shows warnings for unknown frontmatter keys and invalid values, with suggestions for the new namespaced schema.
 ```
 
 Notes about E2E and CI
@@ -140,4 +148,3 @@ Next steps I can take for you
 - Remove the lightweight debug instrumentation that was temporarily added to `slider.html` during troubleshooting.
 - Make the README shorter or add visuals (screenshots/GIF).
 - Open a PR with these README changes.
-

--- a/dev-tools/validate-deck.js
+++ b/dev-tools/validate-deck.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/*
+ Validate a Markdown deck for Slider.
+ - Warns on unknown keys and invalid values for deck-level and per-slide frontmatter
+ - Suggests modern namespaced keys for legacy keys
+ Usage:
+   node dev-tools/validate-deck.js path/to/deck.md
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function readFile(p){ return fs.readFileSync(p, 'utf8'); }
+
+function normalizeNewlines(s){ return s.replace(/\r\n?/g, '\n'); }
+function unquote(s){ return String(s||'').trim().replace(/^['"]|['"]$/g, ''); }
+
+// Allowed keys and migration suggestions
+const migrationMap = new Map([
+  // Deck-level colors & theme
+  ['primary', 'theme-primary'],
+  ['accent', 'theme-accent'],
+  ['textColor', 'theme-text'],
+  ['text-color', 'theme-text'],
+  ['text', 'theme-text'],
+  ['effectColor', 'effect-color'],
+  ['effect', 'effect-color'],
+  ['appname', 'app-name'],
+  ['brand', 'app-name'],
+  ['appBg1', 'defaults-slide-bg1'],
+  ['app-bg1', 'defaults-slide-bg1'],
+  ['app-bg-1', 'defaults-slide-bg1'],
+  ['appBg2', 'defaults-slide-bg2'],
+  ['app-bg2', 'defaults-slide-bg2'],
+  ['app-bg-2', 'defaults-slide-bg2'],
+  ['slideOpacity', 'defaults-slide-opacity'],
+  ['opacity', 'defaults-slide-opacity'],
+  ['primaryFont', 'font-primary'],
+  ['secondaryFont', 'font-secondary'],
+  // Deck overlay defaults
+  ['overlayPos', 'defaults-overlay-pos'],
+  ['titlePosition', 'defaults-overlay-pos'],
+  ['titleSize', 'defaults-title-size'],
+  ['overlaySubtitleSize', 'defaults-subtitle-size'],
+  ['subtitleSize', 'defaults-subtitle-size'],
+  ['overlaySubtitle', 'defaults-overlay'],
+  ['subtitleEnabled', 'defaults-overlay'],
+  // Per-slide
+  ['overlaypos', 'overlay-pos'],
+  ['titlesize', 'title-size'],
+  ['subtitlesize', 'subtitle-size'],
+  ['slidebg1', 'slide-bg1'],
+  ['slidebg2', 'slide-bg2'],
+]);
+
+const allowedDeck = new Set([
+  // Theme/App
+  'app-name', 'appname', 'brand',
+  'theme-primary', 'theme-accent', 'theme-text',
+  'primary', 'accent', 'textColor', 'text-color', 'text',
+  'background', 'effect-color', 'effectColor', 'effect', 'ui',
+  'font-primary', 'font-secondary', 'primaryFont', 'secondaryFont',
+  // Defaults
+  'defaults-overlay', 'defaults-overlay-pos',
+  'defaults-title-size', 'defaults-subtitle-size',
+  'defaults-slide-opacity', 'defaults-slide-bg1', 'defaults-slide-bg2',
+  // Legacy app-bg as deck defaults
+  'appBg1', 'appBg2', 'app-bg1', 'app-bg2', 'app-bg-1', 'app-bg-2',
+  // Legacy opacity
+  'opacity', 'slideOpacity',
+]);
+
+const allowedSlide = new Set([
+  'title', 'subtitle', 'notes',
+  'overlay', 'overlay-pos', 'overlaypos',
+  'title-size', 'titlesize',
+  'subtitle-size', 'subtitlesize',
+  'slide-bg1', 'slide-bg2', 'slidebg1', 'slidebg2',
+]);
+
+function isHex(s){ const x = unquote(s); return /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(x); }
+function isBgMode(s){ return ['gradient','particles','off'].includes(String(s).trim().toLowerCase()); }
+function isBoolLike(s){ return /^(on|off|show|hide|true|false|1|0)$/i.test(String(s).trim()); }
+function isOverlayPos(s){ return ['tl','tr','bl','br'].includes(String(s).trim().toLowerCase()); }
+function clamp(n, lo, hi){ n=Number(n); if(!isFinite(n)) return null; return Math.max(lo, Math.min(hi, n)); }
+function parseOpacity(raw){
+  const s = String(raw||'').trim(); if(!s) return null;
+  if(/%$/.test(s)) return clamp(parseFloat(s), 0, 100);
+  const num = parseFloat(s);
+  if(!isFinite(num)) return null;
+  if(num<=1) return clamp(num*100, 0, 100);
+  return clamp(num, 0, 100);
+}
+
+function parseFrontmatterAtStart(text){
+  const src = normalizeNewlines(text);
+  const t = src.trimStart();
+  if(!t.startsWith('---')) return { fm:{}, body: src };
+  const lines = t.split('\n');
+  let endIndex = -1;
+  for(let i=1;i<lines.length;i++){
+    const raw = lines[i]; const tr=raw.trim();
+    if((raw.startsWith('---')||raw.startsWith('...')) && (tr==='---'||tr==='...')){ endIndex=i; break; }
+  }
+  if(endIndex<=0) return { fm:{}, body: src };
+  const fm = {}; let key=null, val=[];
+  for(let i=1;i<endIndex;i++){
+    const raw=lines[i];
+    const m = raw.match(/^\s*([^:\s][^:]*)\s*:\s*(.*)$/);
+    if(m){ if(key){ fm[key] = val.join(' ').trim(); } key = m[1].trim(); val=[(m[2]||'').trim()]; }
+    else if(key){ val.push(raw.trim()); }
+  }
+  if(key){ fm[key] = val.join(' ').trim(); }
+  const body = lines.slice(endIndex+1).join('\n');
+  return { fm, body };
+}
+
+// Scan slides and per-slide FM (approximation of app logic; keeps key compat)
+function scanSlidesFMs(text){
+  let md = normalizeNewlines(text);
+  if(md.startsWith('\uFEFF')) md = md.slice(1);
+  const lines = md.split('\n');
+  const slides=[]; let buf=[]; let atStart=true; let inFM=false; let inFence=false; let fenceToken=''; let inComment=false; let inHtmlBlock=false;
+  const isSep = (t)=> t==='---';
+  function fenceToggle(t){ const m=t.match(/^(```+|~~~+)/); if(!m) return false; const tok=m[1]; if(!inFence){ inFence=true; fenceToken=tok; } else if(tok===fenceToken){ inFence=false; fenceToken=''; } return true; }
+  function commentToggle(line){ if(/<!--/.test(line)) { inComment=true; return true; } if(/-->/.test(line)) { inComment=false; return true; } return false; }
+  function htmlBlockToggle(t){ if(/^<pre\b/i.test(t)) { inHtmlBlock=true; return true; } if(/^<\/pre>\s*$/.test(t)) { inHtmlBlock=false; return true; } return false; }
+  function looksLikeFrontmatter(i){ let sawKey=false; for(let j=i+1;j<Math.min(lines.length, i+15);j++){ const tj=lines[j].trim(); if(tj==='---'||tj==='...') return sawKey; if(/^\s*$/.test(tj)) continue; if(/^[^\s][^:]*:\s*.*$/.test(tj)) sawKey=true; else return false; } return false; }
+  function pushSlide(){ const content=buf.join('\n').trim(); if(content) slides.push(content); buf=[]; atStart=true; inFM=false; }
+  for(let i=0;i<lines.length;i++){
+    const line=lines[i]; const t=line.trim();
+    if(fenceToggle(t)) { buf.push(line); if(t!=='') atStart=false; continue; }
+    if(commentToggle(line)) { buf.push(line); if(t!=='') atStart=false; continue; }
+    if(htmlBlockToggle(t)) { buf.push(line); if(t!=='') atStart=false; continue; }
+    if(inFM){ buf.push(line); if(isSep(t) || t==='...') { inFM=false; } continue; }
+    if(isSep(t) && !inFence && !inComment && !inHtmlBlock){
+      if(atStart){ inFM=true; buf.push(line); continue; }
+      if(looksLikeFrontmatter(i)){ pushSlide(); buf=[]; atStart=true; inFM=true; buf.push(line); continue; }
+      pushSlide(); continue;
+    }
+    buf.push(line); if(t!=='') atStart=false;
+  }
+  pushSlide();
+  // Extract per-slide FM keys
+  const perSlide = [];
+  for(const s of slides){
+    const { fm } = parseFrontmatterAtStart(s);
+    perSlide.push(fm);
+  }
+  return perSlide;
+}
+
+function validateDeck(deckPath){
+  const src = readFile(deckPath);
+  const { fm: deckFM } = parseFrontmatterAtStart(src);
+  const slideFMs = scanSlidesFMs(src).slice(1); // exclude deck-level if present
+
+  const warnings = [];
+  const add = (msg) => warnings.push(msg);
+
+  // Validate deck keys
+  for(const [rawKey, rawVal] of Object.entries(deckFM)){
+    const key = String(rawKey).trim();
+    if(!allowedDeck.has(key)){
+      const sug = migrationMap.get(key);
+      add(`Deck: unknown key '${key}'${sug? ` (did you mean '${sug}'?)`: ''}`);
+    }
+    if(migrationMap.has(key)){
+      add(`Deck: legacy key '${key}' — prefer '${migrationMap.get(key)}'`);
+    }
+    const v = rawVal;
+    switch(key){
+      case 'theme-primary': case 'theme-accent': case 'theme-text':
+      case 'primary': case 'accent': case 'textColor': case 'text-color': case 'text':
+      case 'effect-color': case 'effectColor': case 'effect':
+      case 'defaults-slide-bg1': case 'defaults-slide-bg2':
+      case 'appBg1': case 'appBg2': case 'app-bg1': case 'app-bg2': case 'app-bg-1': case 'app-bg-2':
+        if(!isHex(v)) add(`Deck: '${key}' expects hex color, got '${v}'`);
+        break;
+      case 'background':
+        if(!isBgMode(v)) add(`Deck: 'background' must be gradient|particles|off, got '${v}'`);
+        break;
+      case 'ui':
+        if(!isBoolLike(v)) add(`Deck: 'ui' must be on|off|show|hide|true|false|1|0, got '${v}'`);
+        break;
+      case 'defaults-overlay':
+        if(!isBoolLike(v)) add(`Deck: 'defaults-overlay' must be true|false|on|off|1|0, got '${v}'`);
+        break;
+      case 'defaults-overlay-pos':
+        if(!isOverlayPos(v)) add(`Deck: 'defaults-overlay-pos' must be tl|tr|bl|br, got '${v}'`);
+        break;
+      case 'defaults-title-size':
+        if(clamp(v,12,64)===null) add(`Deck: 'defaults-title-size' must be a number 12..64, got '${v}'`);
+        break;
+      case 'defaults-subtitle-size':
+        if(clamp(v,10,48)===null) add(`Deck: 'defaults-subtitle-size' must be a number 10..48, got '${v}'`);
+        break;
+      case 'defaults-slide-opacity': case 'opacity': case 'slideOpacity':
+        if(parseOpacity(v)===null) add(`Deck: '${key}' must be 0..100, 0..1, or a percent string, got '${v}'`);
+        break;
+      case 'font-primary': case 'font-secondary': case 'primaryFont': case 'secondaryFont':
+        if(!String(v||'').trim()) add(`Deck: '${key}' should be a non-empty font list`);
+        break;
+    }
+  }
+
+  // Validate per-slide keys
+  slideFMs.forEach((fm, idx)=>{
+    const n = idx+1;
+    for(const [rawKey, rawVal] of Object.entries(fm)){
+      const key = String(rawKey).trim();
+      if(!allowedSlide.has(key)){
+        const sug = migrationMap.get(key);
+        add(`Slide ${n}: unknown key '${key}'${sug? ` (did you mean '${sug}'?)`: ''}`);
+      }
+      if(migrationMap.has(key)){
+        add(`Slide ${n}: legacy key '${key}' — prefer '${migrationMap.get(key)}'`);
+      }
+      const v = rawVal;
+      switch(key){
+        case 'slide-bg1': case 'slide-bg2': case 'slidebg1': case 'slidebg2':
+          if(!isHex(v)) add(`Slide ${n}: '${key}' expects hex color, got '${v}'`);
+          break;
+        case 'overlay':
+          if(!isBoolLike(v)) add(`Slide ${n}: 'overlay' must be true|false|on|off|1|0, got '${v}'`);
+          break;
+        case 'overlay-pos': case 'overlaypos':
+          if(!isOverlayPos(v)) add(`Slide ${n}: '${key}' must be tl|tr|bl|br, got '${v}'`);
+          break;
+        case 'title-size': case 'titlesize':
+          if(clamp(v,12,64)===null) add(`Slide ${n}: '${key}' must be a number 12..64, got '${v}'`);
+          break;
+        case 'subtitle-size': case 'subtitlesize':
+          if(clamp(v,10,48)===null) add(`Slide ${n}: '${key}' must be a number 10..48, got '${v}'`);
+          break;
+      }
+    }
+  });
+
+  return warnings;
+}
+
+function main(){
+  const file = process.argv[2];
+  if(!file){
+    console.error('Usage: node dev-tools/validate-deck.js path/to/deck.md');
+    process.exit(2);
+  }
+  const p = path.resolve(process.cwd(), file);
+  if(!fs.existsSync(p)){
+    console.error(`File not found: ${p}`);
+    process.exit(2);
+  }
+  const warnings = validateDeck(p);
+  if(!warnings.length){
+    console.log(`✔ Deck is valid: ${file}`);
+    process.exit(0);
+  }
+  console.log(`⚠ Found ${warnings.length} warning(s):`);
+  for(const w of warnings){ console.log(' - ' + w); }
+  // Non-zero to integrate with CI if desired
+  process.exit(1);
+}
+
+if(require.main === module){ main(); }
+

--- a/docs/markdown-spec.md
+++ b/docs/markdown-spec.md
@@ -1,0 +1,188 @@
+# Markdown Handling Specification
+
+Last updated: 2025-08-31
+
+This document describes how the single-file app (`slider.html`) parses Markdown, applies frontmatter, splits slides, sanitizes HTML, and maps results to application behavior and styling. It is a code-accurate baseline for future optimizations.
+
+## Scope and Entrypoints
+
+- Core functions in `slider.html`:
+  - `parseFrontmatter(text)` — parse YAML-like frontmatter block.
+  - `parseMarkdown(md, opts)` — convert Markdown to HTML with a few extensions.
+  - `splitSlides(md)` — split a deck into slides, with per-slide frontmatter.
+  - `applyDeckFrontmatter(fm)` — apply deck-level settings (colors, modes, overlay, etc.).
+- Rendering pipeline:
+  1) Load text (upload/restore/sample) → 2) `splitSlides` → 3) `renderSlides` → 4) `applyDeckFrontmatter` → 5) build per-slide overlays.
+
+## Loading Sources
+
+- Upload: `#fileInput` accepts `.md/.markdown/.txt` (MIME guard). Size limit 5 MB. Empty files rejected.
+- Restore order:
+  1) Session restore from `sessionStorage['slideapp.session.deck']` (always attempted).
+  2) Persistent restore from `localStorage['slideapp.persist.deck']` if `CONFIG.rememberLastDeck` is true.
+  3) Fallback fetch of `sample_presentation.md`; if unavailable, an embedded demo deck is used.
+- Persistence when loading:
+  - Saves `{ deckContent, fileName, loadedAt }` to sessionStorage.
+  - Also saves to localStorage when `CONFIG.rememberLastDeck === true`.
+  - Very large decks (> ~2.5 MB) are not persisted.
+
+## Slide Splitting Rules
+
+Normalization and guards
+- Normalizes newlines to `\n` and strips BOM.
+- Tracks regions to avoid splitting on `---` inside:
+  - Fenced code blocks: ``` or ~~~ (length ≥ 3), matched by the same fence.
+  - HTML comments: `<!-- ... -->`.
+  - Simple HTML blocks (e.g., `<pre>…</pre>`), via a lightweight start/stop toggle.
+
+Frontmatter and separators
+- A line containing only `---` at the true start of a slide opens frontmatter; it closes on a dedicated `---` or `...` line at true line start.
+- If `---` appears mid-slide and the following content “looks like frontmatter,” it ends the current slide and starts a new slide with frontmatter.
+- Otherwise, a standalone `---` is treated as a slide separator (when not inside guarded regions).
+- Lines of 4+ hyphens are treated as horizontal rules and ignored at a fresh slide start (do not force a split).
+
+Per-slide processing
+- Each slide string is parsed with `parseFrontmatter` (per-slide FM), then the remaining body is converted with `parseMarkdown`.
+- Fenced ````notes` sections inside a slide body are extracted to `fm.notes` and removed from the rendered HTML.
+
+## Frontmatter Format
+
+Syntax
+- YAML-like `key: value` lines between the opening and closing fence.
+- Keys are case-insensitive; values may span multiple lines by continuing lines without a `key:` pattern.
+- Hex color values may be quoted; quotes are stripped and normalized.
+
+Deck-level frontmatter (file start)
+- Background mode:
+  - Keys: `background`, `bg`.
+  - Values: `gradient` | `particles` | `off`.
+  - Effect: sets background mode and button label.
+- App name / brand:
+  - Keys: `appname`, `app-name`, `brand` (legacy).
+  - Effect: sets `CONFIG.appName` and (legacy) `CONFIG.brand`.
+- Colors (hex, normalized):
+  - Primary: `primary` or `theme-primary` → `CONFIG.primary`.
+  - Accent: `accent` or `theme-accent` → `CONFIG.accent`.
+  - App background: `appBg1` | `app-bg1` | `app-bg-1` → `CONFIG.appBg1`; `appBg2` | `app-bg2` | `app-bg-2` → `CONFIG.appBg2`.
+  - Effect color: `effectColor` | `effect-color` | `effect` → `CONFIG.effectColor`.
+  - Text color: `textColor` | `text-color` | `text` | `theme-text` → `CONFIG.textColor`.
+- Opacity:
+  - Keys: `opacity`, `slideOpacity`, `defaults-slide-opacity`.
+  - Accepted: percent string with `%`, decimal `0..1`, or number `0..100`; clamped to 0–100.
+  - Stored as decimal `CONFIG.slideOpacity`; applies slide background CSS (`--slide-bg1/2`, `--slide-blur`, `--slide-shadow`, `--slide-opacity`).
+- Typography:
+  - `primaryFont` | `font-primary` → `CONFIG.fontPrimary`; `secondaryFont` | `font-secondary` → `CONFIG.fontSecondary`.
+- Title overlay (deck defaults with legacy/namespaced aliases):
+  - Enable: `overlay` (true/on/1) or `titleOverlay` (legacy).
+  - Position: `overlayPos` | `titlePosition` | `defaults-overlay-pos` ∈ {`tl`,`tr`,`bl`,`br`}.
+  - Sizes: `titleSize` | `defaults-title-size` (12–64 px), `overlaySubtitleSize` | `subtitleSize` | `defaults-subtitle-size` (10–48 px).
+  - Subtitle toggle: `overlaySubtitle` | `subtitleEnabled` (false/off/0 disables).
+  - Subtitle color: `overlaySubtitleColor` ∈ {`primary`,`accent`}.
+- UI mode:
+  - Key: `ui` ∈ {on/show/true/1, off/hide/false/0}.
+  - Effect: toggles chrome visibility; persisted to `localStorage['uiMode']`.
+
+Per-slide frontmatter (applies to individual slides)
+- Background overrides (hex): `slideBg1` | `slide-bg1`, `slideBg2` | `slide-bg2`.
+  - Effect: inline gradient override for that slide; attributes `data-slide-bg-override`, `data-slidebg1`, `data-slidebg2` set for inspection.
+- Title/subtitle: `title`, `subtitle`.
+  - Title also used for thumbnail label; fallback `Slide N`.
+- Overlay per-slide:
+  - `overlay` true/on/1 shows, false/off/0 hides (respects deck default when unspecified). If unspecified but `overlay-pos`, `title-size`, or `subtitle-size` are present, overlay is treated as on for that slide.
+  - `overlay-pos`, `title-size`, `subtitle-size` override deck defaults (legacy `overlaypos`, `titlesize`, `subtitlesize` also accepted).
+- Notes: ` ```notes ... ``` ` sections extracted to `fm.notes`.
+
+## Markdown Features
+
+- Fenced code blocks:
+  - Fences ``` or ~~~ with optional language → `<pre><code class="lang-...">…</code></pre>`; contents HTML-escaped.
+  - Preserved with placeholders during parsing to avoid interference.
+- Inline code: `` `code` `` → `<code>`.
+- Columns shortcode:
+  - `::: columns` … `:::col` … `:::` → `<div class="cols"><div class="col">…</div>…</div>`.
+  - Nested content parsed recursively with columns disabled to prevent recursion.
+- Headings: `#`, `##`, `###` at line start → `<h1>`, `<h2>`, `<h3>`.
+- Blockquotes: `> ` prefix → `<blockquote>`.
+- Images: `![alt](url)` → `<img ...>` with safe, inline presentation styles.
+- Links: `[text](url)` → `<a target="_blank" rel="noopener">`.
+- Tables (GFM): header row, separator row (`---` with optional `:` for alignment), and body rows; per-column alignment supported.
+- Lists: `-`/`*` unordered, `1.` ordered; opens/closes `<ul>/<ol>` appropriately.
+- Emphasis: `**bold**`, `*italic*`.
+- Paragraphs: split on double newlines; avoids wrapping block-level elements and code placeholders; single `\n` becomes `<br>` inside paragraphs.
+
+## Sanitization and Safety
+
+- Disallowed tags removed: `script`, `style`, `iframe`, `object`, `embed`.
+- Allowed attributes: `class`, `href`, `src`, `alt`, `title`, `target`, `rel`, `style`.
+- Styles: only a curated set of properties is retained (layout, spacing, color, background, size, opacity, etc.).
+- Images: `src` must be `http(s)` or `data:image/*`.
+- Links: bare `www.` and protocol-relative URLs normalized to `https://…`; forced `target="_blank"` and `rel="noopener"`.
+
+## Styling and Behavior Mapping
+
+- Theme application:
+  - Uses `window.Theme.applyConfig` when available (fallback to inline `applyConfig`).
+  - Sets CSS vars: `--primary`, `--accent`, `--text`, `--btn-bg`, `--muted` (derived), `--app-bg1/2`, `--effect-color`, slide opacity vars, fonts `--font-primary/secondary`, `--outline-w`, and overlay sizes `--title-size/--subtitle-size`.
+  - Toggles classes like `border-off` via helpers.
+- Background mode:
+  - `gradient`/`particles`/`off` reflected in classes and the background button label; honors reduced-motion.
+- Overlays:
+  - Built after rendering when `CONFIG.overlayOn` is true; per-slide FM can hide/override position and sizes; subtitle adopts deck color choice.
+- Thumbnails:
+  - Title text from per-slide `title` (fallback `Slide N`); accessible roles/labels; active thumb shows a primary→accent gradient background.
+- UI mode:
+  - `ui` deck FM toggles chrome visibility; progress/slides drawer can temporarily override and are reset on UI toggle/deck load.
+
+## Persistence and Determinism
+
+- Session key: `slideapp.session.deck` (always used when present and valid).
+- Persistent key: `slideapp.persist.deck` (used only when configured to remember).
+- Deterministic test mode hook (`window.__isDeterministicTestMode()`): when enabled in tests, clears stored background mode and prefers `gradient` to keep visuals stable.
+
+## Constraints and Limits
+
+- Upload limit: 5 MB; very large decks (> ~2.5 MB) are not persisted.
+- Accepted types: `.md`, `.markdown`, `.txt` plus common text MIME types.
+- Hex colors accepted with or without quotes; normalized to `#rrggbb`.
+
+## Accessibility Notes
+
+- Thumbnails are keyboard-activatable buttons (`role="button"`, `tabindex="0"`, `Enter`/`Space` handling, ARIA labels).
+- Slide overlays are marked `aria-hidden="true"` to avoid duplicating text for assistive tech.
+
+## Non‑Goals and Known Behavior
+
+- Markdown subset: intentionally lightweight; no full CommonMark; feature set is driven by tests and core app needs.
+- Math/diagrams/footnotes/admonitions are not built-in (candidates for future additions).
+
+## Migration Guide (Legacy → Namespaced)
+
+Use the right column where possible; legacy keys remain supported but may emit warnings in validation.
+
+- Theme & App
+  - primary → theme-primary
+  - accent → theme-accent
+  - textColor | text-color | text → theme-text
+  - appname | brand → app-name
+  - effectColor | effect → effect-color
+  - primaryFont → font-primary
+  - secondaryFont → font-secondary
+
+- Defaults (Deck-level)
+  - overlay → defaults-overlay (for default visibility)
+  - overlayPos | titlePosition → defaults-overlay-pos
+  - titleSize → defaults-title-size
+  - overlaySubtitleSize | subtitleSize → defaults-subtitle-size
+  - opacity | slideOpacity → defaults-slide-opacity
+  - appBg1 → defaults-slide-bg1
+  - appBg2 → defaults-slide-bg2
+
+- Per-slide
+  - overlaypos → overlay-pos
+  - titlesize → title-size
+  - subtitlesize → subtitle-size
+  - slidebg1 → slide-bg1
+  - slidebg2 → slide-bg2
+
+Validation Tool
+- Run `npm run validate:deck -- <file.md>` to surface unknown keys and invalid values, with suggestions for namespaced keys.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:all": "playwright test",
     "test:unit": "vitest run unit --reporter verbose",
     "lint": "eslint \"**/*.{js,ts}\" --max-warnings=0",
-    "test:e2e": "playwright test tests"
+    "test:e2e": "playwright test tests",
+    "validate:deck": "node dev-tools/validate-deck.js"
   },
   "keywords": [],
   "author": "",

--- a/slider.html
+++ b/slider.html
@@ -243,6 +243,7 @@
         <button class="btn" id="uiBtn" title="Toggle UI visibility" aria-label="Toggle UI">👁️ UI</button>
         <input type="file" id="fileInput" class="btn" accept=".md,.markdown,.txt" title="Load Markdown" aria-label="Load Markdown" />
         <button class="btn" id="styleBtn" title="Style settings" aria-label="Style">🎨 Style</button>
+        <button class="btn" id="validateBtn" title="Validate deck frontmatter" aria-label="Validate">🔎 Validate</button>
   <button class="btn" id="overlayBtn" title="Toggle title/subtitle overlay" aria-label="Overlay">🏷️ Title</button>
         <button class="btn" id="bgBtn" title="Toggle Background" aria-label="Background">🌌 Background</button>
         <button class="btn" id="notesBtn" aria-label="Notes">📝 Notes</button>
@@ -400,6 +401,18 @@
     <footer>
       <button class="btn" id="cfgReset" title="Reset to defaults">↺ Reset</button>
       <button class="btn" id="cfgSave">Save</button>
+    </footer>
+  </div>
+  <!-- Validation modal -->
+  <div id="valOverlay" style="position:fixed;inset:0;background:rgba(0,0,0,.35);backdrop-filter:blur(2px);display:none;z-index:30"></div>
+  <div id="valModal" role="dialog" aria-modal="true" aria-labelledby="valTitle" style="position:fixed;top:40px;bottom:40px;left:40px;right:40px;width:auto;max-width:none;background:linear-gradient(135deg,var(--app-bg1, #0b1220),var(--app-bg2, #0f172a));color:var(--text);border:1px solid rgba(255,255,255,.08);border-radius:12px;box-shadow:var(--shadow);display:none;z-index:31;flex-direction:column">
+    <header style="display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid rgba(255,255,255,.08);flex:0 0 auto">
+      <h3 id="valTitle" style="margin:0;font-weight:600">Deck Validation</h3>
+      <button class="btn" id="valClose">Close</button>
+    </header>
+    <main id="valBody" style="padding:14px;overflow:auto;flex:1 1 auto;font-size:14px;line-height:1.4"></main>
+    <footer style="display:flex;gap:8px;justify-content:flex-end;padding:12px 14px;border-top:1px solid rgba(255,255,255,.08);flex:0 0 auto;background:linear-gradient(180deg, rgba(0,0,0,0.06), rgba(0,0,0,0.12));backdrop-filter:blur(4px)">
+      <button class="btn" id="valOk">OK</button>
     </footer>
   </div>
 
@@ -1194,11 +1207,15 @@
         slides.forEach((slideEl, idx)=>{
           const fm = list[idx]?.fm || {};
           // per-slide overrides
-          const slideOverlayFlag = (typeof fm.overlay !== 'undefined') ? /^(1|on|true)$/i.test(String(fm.overlay).trim()) : true;
+          const slideOverlayFlagVal = (typeof fm.overlay !== 'undefined') ? String(fm.overlay).trim()
+            : (typeof fm['overlay-pos'] !== 'undefined' || typeof fm['title-size'] !== 'undefined' || typeof fm['subtitle-size'] !== 'undefined') ? 'on' : undefined;
+          const slideOverlayFlag = (typeof slideOverlayFlagVal !== 'undefined') ? /^(1|on|true)$/i.test(slideOverlayFlagVal) : true;
           if(!slideOverlayFlag) return;
-          const pos = (fm.overlaypos || CONFIG.overlayPos || 'tl').toString().toLowerCase();
-          const tSize = isFinite(Number(fm.titlesize)) ? Math.max(12, Math.min(64, Math.round(Number(fm.titlesize)))) : CONFIG.overlayTitleSize;
-          const sSize = isFinite(Number(fm.subtitlesize)) ? Math.max(10, Math.min(48, Math.round(Number(fm.subtitlesize)))) : CONFIG.overlaySubtitleSize;
+          const pos = (fm['overlay-pos'] || fm.overlaypos || CONFIG.overlayPos || 'tl').toString().toLowerCase();
+          const tSizeRaw = (typeof fm['title-size'] !== 'undefined') ? fm['title-size'] : fm.titlesize;
+          const sSizeRaw = (typeof fm['subtitle-size'] !== 'undefined') ? fm['subtitle-size'] : fm.subtitlesize;
+          const tSize = isFinite(Number(tSizeRaw)) ? Math.max(12, Math.min(64, Math.round(Number(tSizeRaw)))) : CONFIG.overlayTitleSize;
+          const sSize = isFinite(Number(sSizeRaw)) ? Math.max(10, Math.min(48, Math.round(Number(sSizeRaw)))) : CONFIG.overlaySubtitleSize;
           const titleTxt = (fm.title||'').toString().trim() || `Slide ${idx+1}`;
           const subtitleTxt = (fm.subtitle||'').toString().trim();
           const wrap = document.createElement('div');
@@ -2253,7 +2270,88 @@ Everything else in front matter is ignored by the app.`;
           if(sc) sc.disabled = disable;
         }
       }catch{}
+  });
+
+  // ===== In-app Deck Validator =====
+  (function initValidator(){
+    const valOverlay = document.getElementById('valOverlay');
+    const valModal = document.getElementById('valModal');
+    const valBody = document.getElementById('valBody');
+    const open = () => { valOverlay.style.display='block'; valModal.style.display='flex'; };
+    const close = () => { valOverlay.style.display='none'; valModal.style.display='none'; };
+    document.getElementById('valClose').addEventListener('click', close);
+    document.getElementById('valOk').addEventListener('click', close);
+    document.getElementById('validateBtn').addEventListener('click', ()=>{
+      const warnings = (()=>{
+        const allowedDeck = new Set(['app-name','appname','brand','theme-primary','theme-accent','theme-text','primary','accent','textcolor','text-color','text','background','effect-color','effectcolor','effect','ui','font-primary','font-secondary','primaryfont','secondaryfont','defaults-overlay','defaults-overlay-pos','defaults-title-size','defaults-subtitle-size','defaults-slide-opacity','defaults-slide-bg1','defaults-slide-bg2','appbg1','appbg2','app-bg1','app-bg2','app-bg-1','app-bg-2','opacity','slideopacity']);
+        const allowedSlide = new Set(['title','subtitle','notes','overlay','overlay-pos','overlaypos','title-size','titlesize','subtitle-size','subtitlesize','slide-bg1','slide-bg2','slidebg1','slidebg2']);
+        const migrate = new Map(Object.entries({
+          primary:'theme-primary', accent:'theme-accent', textcolor:'theme-text', 'text-color':'theme-text', text:'theme-text', effectcolor:'effect-color', effect:'effect-color', appname:'app-name', brand:'app-name', appbg1:'defaults-slide-bg1', 'app-bg1':'defaults-slide-bg1', 'app-bg-1':'defaults-slide-bg1', appbg2:'defaults-slide-bg2', 'app-bg2':'defaults-slide-bg2', 'app-bg-2':'defaults-slide-bg2', slideopacity:'defaults-slide-opacity', opacity:'defaults-slide-opacity', primaryfont:'font-primary', secondaryfont:'font-secondary', overlaypos:'overlay-pos', titlesize:'title-size', subtitlesize:'subtitle-size', slidebg1:'slide-bg1', slidebg2:'slide-bg2'
+        }));
+        const isHex=(s)=>/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test((s||'').toString().trim().replace(/^['"]|['"]$/g,''));
+        const isBg=(s)=>['gradient','particles','off'].includes((s||'').toString().trim().toLowerCase());
+        const isBool=(s)=>/^(on|off|show|hide|true|false|1|0)$/i.test((s||'').toString().trim());
+        const isPos=(s)=>['tl','tr','bl','br'].includes((s||'').toString().trim().toLowerCase());
+        const clamp=(n,lo,hi)=>{ n=Number(n); if(!isFinite(n)) return null; return Math.max(lo, Math.min(hi, n)); };
+        const parseOpacity=(raw)=>{ const s=(raw||'').toString().trim(); if(!s) return null; if(/%$/.test(s)) return clamp(parseFloat(s),0,100); const num=parseFloat(s); if(!isFinite(num)) return null; if(num<=1) return clamp(num*100,0,100); return clamp(num,0,100); };
+        const out=[];
+        try{
+          const deckFM = (Array.isArray(slidesHTML) && slidesHTML.length) ? (slidesHTML[0]?.fm || {}) : {};
+          for(const [kRaw,v] of Object.entries(deckFM)){
+            const k = String(kRaw).trim().toLowerCase();
+            if(!allowedDeck.has(k)){
+              const sug = migrate.get(k);
+              out.push(`Deck: unknown key '${kRaw}'${sug? ` (did you mean '${sug}'?)`: ''}`);
+            }
+            if(migrate.has(k)) out.push(`Deck: legacy key '${kRaw}' — prefer '${migrate.get(k)}'`);
+            switch(k){
+              case 'theme-primary': case 'theme-accent': case 'theme-text':
+              case 'primary': case 'accent': case 'textcolor': case 'text-color': case 'text':
+              case 'effect-color': case 'effectcolor': case 'effect':
+              case 'defaults-slide-bg1': case 'defaults-slide-bg2':
+              case 'appbg1': case 'appbg2': case 'app-bg1': case 'app-bg2': case 'app-bg-1': case 'app-bg-2':
+                if(!isHex(v)) out.push(`Deck: '${kRaw}' expects hex color, got '${v}'`);
+                break;
+              case 'background': if(!isBg(v)) out.push(`Deck: 'background' must be gradient|particles|off, got '${v}'`); break;
+              case 'ui': if(!isBool(v)) out.push(`Deck: 'ui' must be on|off|show|hide|true|false|1|0, got '${v}'`); break;
+              case 'defaults-overlay': if(!isBool(v)) out.push(`Deck: 'defaults-overlay' must be true|false|on|off|1|0, got '${v}'`); break;
+              case 'defaults-overlay-pos': if(!isPos(v)) out.push(`Deck: 'defaults-overlay-pos' must be tl|tr|bl|br, got '${v}'`); break;
+              case 'defaults-title-size': if(clamp(v,12,64)===null) out.push(`Deck: 'defaults-title-size' must be 12..64, got '${v}'`); break;
+              case 'defaults-subtitle-size': if(clamp(v,10,48)===null) out.push(`Deck: 'defaults-subtitle-size' must be 10..48, got '${v}'`); break;
+              case 'defaults-slide-opacity': case 'opacity': case 'slideopacity': if(parseOpacity(v)===null) out.push(`Deck: '${kRaw}' must be 0..100, 0..1, or a percent string, got '${v}'`); break;
+            }
+          }
+          // Per-slide
+          (slidesHTML||[]).slice(1).forEach((s,idx)=>{
+            const fm = s?.fm || {}; const n=idx+1;
+            for(const [kRaw,v] of Object.entries(fm)){
+              const k = String(kRaw).trim().toLowerCase();
+              if(!allowedSlide.has(k)){
+                const sug = migrate.get(k);
+                out.push(`Slide ${n}: unknown key '${kRaw}'${sug? ` (did you mean '${sug}'?)`: ''}`);
+              }
+              if(migrate.has(k)) out.push(`Slide ${n}: legacy key '${kRaw}' — prefer '${migrate.get(k)}'`);
+              switch(k){
+                case 'slide-bg1': case 'slide-bg2': case 'slidebg1': case 'slidebg2': if(!isHex(v)) out.push(`Slide ${n}: '${kRaw}' expects hex color, got '${v}'`); break;
+                case 'overlay': if(!isBool(v)) out.push(`Slide ${n}: 'overlay' must be true|false|on|off|1|0, got '${v}'`); break;
+                case 'overlay-pos': case 'overlaypos': if(!isPos(v)) out.push(`Slide ${n}: '${kRaw}' must be tl|tr|bl|br, got '${v}'`); break;
+                case 'title-size': case 'titlesize': if(clamp(v,12,64)===null) out.push(`Slide ${n}: '${kRaw}' must be 12..64, got '${v}'`); break;
+                case 'subtitle-size': case 'subtitlesize': if(clamp(v,10,48)===null) out.push(`Slide ${n}: '${kRaw}' must be 10..48, got '${v}'`); break;
+              }
+            }
+          });
+        }catch(e){ out.push('Validator error: '+(e&&e.message)); }
+        return out;
+      })();
+      // Render
+      if(!warnings.length){ valBody.innerHTML='<p style="margin:0">✅ No issues found.</p>'; }
+      else {
+        const list = warnings.map(w=>`<li>${w.replace(/&/g,'&amp;').replace(/</g,'&lt;')}</li>`).join('');
+        valBody.innerHTML = `<p style="margin-top:0">⚠ Found ${warnings.length} warning(s):</p><ul style="margin:8px 0 0 18px;">${list}</ul>`;
+      }
+      open();
     });
+  })();
   })();
 
   // ===== Deck-level frontmatter application =====
@@ -2275,15 +2373,21 @@ Everything else in front matter is ignored by the app.`;
     const hexRe = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
       const strip = s=> (s||'').toString().trim().replace(/^['"]|['"]$/g,'');
       try{
-        const pRaw = strip(fm.primary||fm.color||'');
+        const pRaw = strip(fm.primary||fm.color|| fm['theme-primary'] || '');
         const p = normalizeHex(pRaw);
         if(p) CONFIG.primary = p;
       }catch{}
       try{
-        const aRaw = strip(fm.accent||'');
+        const aRaw = strip(fm.accent|| fm['theme-accent'] || '');
         const a = normalizeHex(aRaw);
         if(a) CONFIG.accent = a;
       }catch{}
+    // Theme text color
+    try{
+      const tRaw = strip(fm['theme-text'] || '');
+      const t = normalizeHex(tRaw);
+      if(t) CONFIG.textColor = t;
+    }catch{}
     // App background colors (hex)
     try{
       const ab1Raw = strip(fm.appbg1 || fm['app-bg1'] || fm['app-bg-1'] || '');
@@ -2295,13 +2399,24 @@ Everything else in front matter is ignored by the app.`;
       const ab2 = normalizeHex(ab2Raw);
       if(ab2) CONFIG.appBg2 = ab2;
     }catch{}
+    // Defaults slide background (deck-level defaults for slides)
+    try{
+      const sb1Raw = strip(fm['defaults-slide-bg1'] || '');
+      const sb1 = normalizeHex(sb1Raw);
+      if(sb1) CONFIG.slideBg1 = sb1;
+    }catch{}
+    try{
+      const sb2Raw = strip(fm['defaults-slide-bg2'] || '');
+      const sb2 = normalizeHex(sb2Raw);
+      if(sb2) CONFIG.slideBg2 = sb2;
+    }catch{}
     // Effect color (hex) used by particles/gradients
     try{
       const ecRaw = strip(fm.effectcolor || fm['effect-color'] || fm.effect || '');
       const ec = normalizeHex(ecRaw);
       if(ec) CONFIG.effectColor = ec;
     }catch{}
-    // Text color
+    // Text color (legacy)
     try{
       const tcRaw = strip(fm.textcolor || fm['text-color'] || fm.text || '');
       const tc = normalizeHex(tcRaw);
@@ -2310,7 +2425,7 @@ Everything else in front matter is ignored by the app.`;
     // Opacity (percent 0-100 or decimal 0-1 or with %)
     let hasOpacity=false; let decOpacity=null;
     try{
-      const raw = strip(fm.opacity || fm.slideopacity || '');
+      const raw = strip(fm.opacity || fm.slideopacity || fm['defaults-slide-opacity'] || '');
       if(raw){
         hasOpacity = true;
         let pct;
@@ -2334,14 +2449,16 @@ Everything else in front matter is ignored by the app.`;
     }
   // Typography and overlays
   try{ if(typeof fm.primaryfont==='string' && fm.primaryfont.trim()) CONFIG.fontPrimary = fm.primaryfont.trim(); }catch{}
+  try{ if(typeof fm['font-primary']==='string' && fm['font-primary'].trim()) CONFIG.fontPrimary = fm['font-primary'].trim(); }catch{}
   try{ if(typeof fm.secondaryfont==='string' && fm.secondaryfont.trim()) CONFIG.fontSecondary = fm.secondaryfont.trim(); }catch{}
-  // overlay (new) and legacy
-  try{ if(typeof fm.overlay!=='undefined'){ const v=String(fm.overlay).trim().toLowerCase(); CONFIG.overlayOn = (v==='true'||v==='1'||v==='on'); } else if(typeof fm.titleoverlay!=='undefined'){ const v=String(fm.titleoverlay).trim().toLowerCase(); CONFIG.overlayOn = (v==='true'||v==='1'||v==='on'); } }catch{}
-  try{ const p=(fm.overlaypos||fm.titleposition||'').toString().toLowerCase(); if(['tl','tr','bl','br'].includes(p)) CONFIG.overlayPos=p; }catch{}
-  try{ if(typeof fm.titlesize!=='undefined'){ const n=Math.round(Number(fm.titlesize)); if(isFinite(n)) CONFIG.overlayTitleSize = Math.max(12, Math.min(64, n)); } }catch{}
-  try{ if(typeof fm.overlaysubtitle!=='undefined'){ const v=String(fm.overlaysubtitle).trim().toLowerCase(); CONFIG.overlaySubtitleOn = !(v==='false'||v==='0'||v==='off'); } else if(typeof fm.subtitleenabled!=='undefined'){ const v=String(fm.subtitleenabled).trim().toLowerCase(); CONFIG.overlaySubtitleOn = !(v==='false'||v==='0'||v==='off'); } }catch{}
-  try{ const n = (typeof fm.overlaysubtitlesize!=='undefined') ? Math.round(Number(fm.overlaysubtitlesize)) : (typeof fm.subtitlesize!=='undefined' ? Math.round(Number(fm.subtitlesize)) : NaN); if(isFinite(n)) CONFIG.overlaySubtitleSize = Math.max(10, Math.min(48, n)); }catch{}
-  try{ const c=(fm.overlaysubtitlecolor||'').toString().toLowerCase(); if(c==='accent'||c==='primary') CONFIG.overlaySubtitleColor=c; }catch{}
+  try{ if(typeof fm['font-secondary']==='string' && fm['font-secondary'].trim()) CONFIG.fontSecondary = fm['font-secondary'].trim(); }catch{}
+  // overlay (new) and legacy + namespaced defaults-
+  try{ if(typeof fm.overlay!=='undefined'){ const v=String(fm.overlay).trim().toLowerCase(); CONFIG.overlayOn = (v==='true'||v==='1'||v==='on'); } else if(typeof fm.titleoverlay!=='undefined'){ const v=String(fm.titleoverlay).trim().toLowerCase(); CONFIG.overlayOn = (v==='true'||v==='1'||v==='on'); } else if(typeof fm['defaults-overlay']!=='undefined'){ const v=String(fm['defaults-overlay']).trim().toLowerCase(); CONFIG.overlayOn = (v==='true'||v==='1'||v==='on'); } }catch{}
+  try{ const p=(fm['overlay-pos']||fm.overlaypos||fm.titleposition||fm['defaults-overlay-pos']||'').toString().toLowerCase(); if(['tl','tr','bl','br'].includes(p)) CONFIG.overlayPos=p; }catch{}
+  try{ const tRaw = (typeof fm['title-size']!=='undefined') ? fm['title-size'] : (typeof fm.titlesize!=='undefined' ? fm.titlesize : fm['defaults-title-size']); const n=Math.round(Number(tRaw)); if(isFinite(n)) CONFIG.overlayTitleSize = Math.max(12, Math.min(64, n)); }catch{}
+  try{ if(typeof fm.overlaysubtitle!=='undefined'){ const v=String(fm.overlaysubtitle).trim().toLowerCase(); CONFIG.overlaySubtitleOn = !(v==='false'||v==='0'||v==='off'); } else if(typeof fm.subtitleenabled!=='undefined'){ const v=String(fm.subtitleenabled).trim().toLowerCase(); CONFIG.overlaySubtitleOn = !(v==='false'||v==='0'||v==='off'); } else if(typeof fm['defaults-overlay']!=='undefined'){ /* already handled by overlayOn */ } }catch{}
+  try{ const sRaw = (typeof fm['overlay-subtitle-size']!=='undefined') ? fm['overlay-subtitle-size'] : (typeof fm.subtitlesize!=='undefined' ? fm.subtitlesize : fm['defaults-subtitle-size']); const n=Math.round(Number(sRaw)); if(isFinite(n)) CONFIG.overlaySubtitleSize = Math.max(10, Math.min(48, n)); }catch{}
+  try{ const c=((fm.overlaysubtitlecolor||'') || (fm['overlay-subtitle-color']||'') ).toString().toLowerCase(); if(c==='accent'||c==='primary') CONFIG.overlaySubtitleColor=c; }catch{}
     applyConfig();
   // Rebuild overlays for current slides
     try{


### PR DESCRIPTION
This PR adds authoring guardrails and documentation around frontmatter:

- In-app validator: "Validate" button to check the currently loaded deck and surface warnings (unknown keys, legacy keys with suggestions, invalid values)
- CLI validator: `dev-tools/validate-deck.js` with `npm run validate:deck -- file.md`
- README: quickstart note and CLI usage for validation
- Docs: migration guide (legacy → namespaced) in `docs/markdown-spec.md`
- CI: non-blocking validation of changed Markdown files in PRs/pushes

Tests
- Lint: pass
- Unit: pass
- E2E (Chromium, Firefox, WebKit): 168 passed, 3 skipped

Notes
- CI validation is non-blocking for adoption; we can switch to blocking once the team is ready.