### PR TITLE
Docs: authoring guide + new Markdown features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Key features
 - Keyboard shortcuts for navigation and quick toggles (Background, UI, Opacity, Outline, Notes, Slides drawer).
 - Theming system and a small Style modal for colors, overlay, and outline settings.
 - Export / print (use browser print to PDF) and fullscreen support.
+ - Enhanced Markdown: strikethrough, task lists, admonitions, autolinked URLs, linkable headings + in‑app TOC.
 
 Quick start (local)
 1. Clone the repo and change to the project folder:
@@ -53,6 +54,7 @@ What to try
 - The app loads `sample_presentation.md` automatically on first run.
 - Click the top toolbar "Load Markdown" button (📁) and choose a Markdown file to load your slides.
 - Navigate with ← / → keys or on-screen arrows; thumbnails appear in the left drawer.
+- Try “Validate” (🔎) to lint your deck’s frontmatter. Use the “📑 TOC” to browse headings and jump around.
 - Validate your deck: Click “Validate” in the header to check frontmatter keys and values. Or run `npm run validate:deck -- path/to/deck.md` locally to lint Markdown decks in CI or pre-commit.
 - Useful keys:
   - B — cycle background modes (Particles → Gradient → Off)
@@ -97,6 +99,20 @@ npm run test:all
 npm run validate:deck -- sample_presentation.md
 ```
 Shows warnings for unknown frontmatter keys and invalid values, with suggestions for the new namespaced schema.
+
+Authoring quick guide
+- Strikethrough: `~~deprecated~~` → ~deprecated~
+- Task list:
+  - [ ] Collect feedback
+  - [x] Ship 1.0.1
+- Admonitions:
+  ::: tip
+  Pro tip: Use the TOC (📑) to jump between sections.
+  :::
+- Autolink literal: paste `https://example.com` — it becomes a link
+- Anchors: h1–h3 get stable ids; click the “#” to copy a link to a heading
+
+See docs/markdown-spec.md for complete details and examples.
 ```
 
 Notes about E2E and CI

--- a/docs/markdown-spec.md
+++ b/docs/markdown-spec.md
@@ -131,6 +131,41 @@ Examples
 
 Notes
 - Headings include `id`s; sanitizer allows `id` and hash links (`href="#slug"`). External links retain `target`/`rel`.
+- Use the in‑app “📑 TOC” to jump to any heading (h1–h3) across slides.
+
+## Authoring Quick Examples
+
+- Strikethrough
+
+  `We are ~~deprecated~~ moving forward.`
+
+- Task list
+
+  - [ ] Collect feedback
+  - [x] Ship 1.0.1
+
+- Admonitions
+
+  ::: note
+  Heads up: Slides now support admonitions.
+  :::
+
+  ::: tip
+  Pro tip: Use the TOC (📑) to jump between sections.
+  :::
+
+  ::: warning
+  Warning: Don’t overuse effects; clarity wins.
+  :::
+
+- Autolink literals
+
+  Visit https://example.com for more.
+
+- Anchors
+
+  ## Getting Started
+  Click the “#” icon on hover to copy a direct link to this heading.
 
 ## Sanitization and Safety
 
@@ -173,6 +208,15 @@ Notes
 - Slide overlays are marked `aria-hidden="true"` to avoid duplicating text for assistive tech.
 
 ## Non‑Goals and Known Behavior
+## What’s New (Authoring Highlights)
+
+- Strikethrough: `~~deprecated~~` → ~deprecated~
+- Task lists: `- [ ] item`, `- [x] item` with clear visual check marks
+- Admonitions: `::: note|tip|warning … :::` with title and body
+- Autolink literals: bare `http(s)://…` become links
+- Linkable headings: h1–h3 get stable `id`s; click the “#” on hover to copy a link
+- In‑app TOC: click “📑 TOC” to browse h1–h3 and jump to slides
+
 
 - Markdown subset: intentionally lightweight; no full CommonMark; feature set is driven by tests and core app needs.
 - Math/diagrams/footnotes/admonitions are not built-in (candidates for future additions).


### PR DESCRIPTION
This docs-only PR updates the authoring experience:

- README: adds an Authoring Quick Guide and mentions Validate + TOC
- docs/markdown-spec.md: adds What’s New digest, polished examples, and quick snippets

No runtime changes. Lint + unit green.