### PR TITLE
Fix: slide frame + overlay not clipped; internal scroll container; padding tweaks

### DIFF
--- a/slider.html
+++ b/slider.html
@@ -66,9 +66,12 @@
   :root{ --btn-bg: linear-gradient(rgba(255,255,255,0.02), rgba(0,0,0,0.04)); --btn-text: var(--text); }
   .btn{ background: var(--btn-bg); color: var(--btn-text); }
 
-    .slides{position:absolute;inset:0;display:block;padding:64px 72px 80px 72px}
+    /* Reserve space using CSS vars so we can position the frame precisely */
+    :root{ --pad-top:96px; --pad-bottom:120px; --pad-side:72px }
+    .slides{position:absolute;inset:0;display:block}
+    body.ui-off :root{ --pad-top:24px; --pad-bottom:32px }
   /* A single framed slide that fills the padded area and scrolls internally */
-  .slide{position:relative;inset:auto;width:100%;height:100%;display:block;background:linear-gradient(180deg,var(--slide-bg1, rgba(17,24,39,.75)),var(--slide-bg2, rgba(17,24,39,.55)));border-radius:var(--radius);box-shadow:var(--slide-shadow, var(--shadow));opacity:0;transform:translate3d(60px,0,0) scale(.98);transition:all 0.6s cubic-bezier(0.4, 0, 0.2, 1);backdrop-filter:blur(var(--slide-blur, 8px));padding:0;overflow:hidden;outline:none}
+  .slide{position:absolute;top:var(--pad-top);bottom:var(--pad-bottom);left:var(--pad-side);right:var(--pad-side);display:block;background:linear-gradient(180deg,var(--slide-bg1, rgba(17,24,39,.75)),var(--slide-bg2, rgba(17,24,39,.55)));border-radius:var(--radius);box-shadow:var(--slide-shadow, var(--shadow));opacity:0;transform:translate3d(60px,0,0) scale(.98);transition:all 0.6s cubic-bezier(0.4, 0, 0.2, 1);backdrop-filter:blur(var(--slide-blur, 8px));padding:0;overflow:hidden;outline:none}
   .slide .content-scroll{position:relative;height:100%;overflow:auto;padding:56px 48px 96px 48px}
   /* Slide title/subtitle overlay */
   .slide .slide-overlay{position:absolute;pointer-events:none;z-index:50;max-width:70%;display:flex;flex-direction:column;gap:4px;text-shadow:0 1px 2px rgba(0,0,0,.35)}
@@ -1383,6 +1386,10 @@
       all[i].classList.add('active');
       all[i].setAttribute('tabindex', '-1');
       all[i].focus({ preventScroll: true });
+      try{
+        const sc = all[i].querySelector('.content-scroll');
+        if(sc) sc.scrollTop = 0;
+      }catch{}
     }
     
     if (all[i - 1]) all[i - 1].classList.add('prev');

--- a/slider.html
+++ b/slider.html
@@ -66,10 +66,12 @@
   :root{ --btn-bg: linear-gradient(rgba(255,255,255,0.02), rgba(0,0,0,0.04)); --btn-text: var(--text); }
   .btn{ background: var(--btn-bg); color: var(--btn-text); }
 
-    .slides{position:absolute;inset:0;display:grid;place-items:center;padding:64px 72px 80px 72px}
-  .slide{position:absolute;inset:72px;display:grid;place-items:center;background:linear-gradient(180deg,var(--slide-bg1, rgba(17,24,39,.75)),var(--slide-bg2, rgba(17,24,39,.55)));border-radius:var(--radius);box-shadow:var(--slide-shadow, var(--shadow));opacity:0;transform:translate3d(60px,0,0) scale(.98);transition:all 0.6s cubic-bezier(0.4, 0, 0.2, 1);backdrop-filter:blur(var(--slide-blur, 8px));padding:48px;overflow:auto;outline:none}
+    .slides{position:absolute;inset:0;display:block;padding:64px 72px 80px 72px}
+  /* A single framed slide that fills the padded area and scrolls internally */
+  .slide{position:relative;inset:auto;width:100%;height:100%;display:block;background:linear-gradient(180deg,var(--slide-bg1, rgba(17,24,39,.75)),var(--slide-bg2, rgba(17,24,39,.55)));border-radius:var(--radius);box-shadow:var(--slide-shadow, var(--shadow));opacity:0;transform:translate3d(60px,0,0) scale(.98);transition:all 0.6s cubic-bezier(0.4, 0, 0.2, 1);backdrop-filter:blur(var(--slide-blur, 8px));padding:0;overflow:hidden;outline:none}
+  .slide .content-scroll{position:relative;height:100%;overflow:auto;padding:56px 48px 96px 48px}
   /* Slide title/subtitle overlay */
-  .slide .slide-overlay{position:absolute;pointer-events:none;z-index:3;max-width:70%;display:flex;flex-direction:column;gap:4px;text-shadow:0 1px 2px rgba(0,0,0,.35)}
+  .slide .slide-overlay{position:absolute;pointer-events:none;z-index:50;max-width:70%;display:flex;flex-direction:column;gap:4px;text-shadow:0 1px 2px rgba(0,0,0,.35)}
   .slide .slide-overlay.pos-tl{top:18px;left:24px;text-align:left}
   .slide .slide-overlay.pos-tr{top:18px;right:24px;text-align:right}
   .slide .slide-overlay.pos-bl{bottom:18px;left:24px;text-align:left}
@@ -1272,6 +1274,14 @@
   }
     }catch{}
   node.innerHTML=sanitizeHTML(obj.html);
+  // Wrap content in a scroll container so overlay and outline are not clipped
+  try{
+    const wrap = document.createElement('div');
+    wrap.className = 'content-scroll';
+    // Move all current children into the wrapper (e.g., .md)
+    while(node.firstChild){ wrap.appendChild(node.firstChild); }
+    node.appendChild(wrap);
+  }catch{}
   // Enhance headings with anchor links
   try{
     const hs = node.querySelectorAll('h1[id],h2[id],h3[id]');

--- a/tests/overlay-not-clipped.spec.ts
+++ b/tests/overlay-not-clipped.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+function toFileUrl(p: string) { return 'file://' + path.resolve(p); }
+
+test('Overlay is visible and not clipped with long content', async ({ page }) => {
+  const appPath = path.resolve(__dirname, '..', 'slider.html');
+  await page.goto(toFileUrl(appPath));
+  await page.waitForSelector('.slide.active');
+
+  // Ensure an overlay is present and positioned (defaults: overlay off; toggle on)
+  // Turn overlay on via the button
+  await page.click('#overlayBtn');
+  await page.waitForSelector('.slide.active .slide-overlay');
+
+  // Scroll the inner content to the bottom
+  await page.evaluate(() => {
+    const sc = document.querySelector('.slide.active .content-scroll') as HTMLElement | null;
+    if (sc) sc.scrollTop = sc.scrollHeight;
+  });
+
+  // Measure overlay and slide bounding rects
+  const rects = await page.evaluate(() => {
+    const slide = document.querySelector('.slide.active') as HTMLElement | null;
+    const overlay = document.querySelector('.slide.active .slide-overlay') as HTMLElement | null;
+    const content = document.querySelector('.slide.active .content-scroll') as HTMLElement | null;
+    if (!slide || !overlay || !content) return null;
+    const s = slide.getBoundingClientRect();
+    const o = overlay.getBoundingClientRect();
+    const c = content.getBoundingClientRect();
+    return { s, o, c };
+  });
+  expect(rects).not.toBeNull();
+  const { s, o } = rects! as any;
+
+  // Assert overlay stays inside the slide frame and is visible
+  expect(o.top).toBeGreaterThanOrEqual(s.top - 1);
+  expect(o.left).toBeGreaterThanOrEqual(s.left - 1);
+  expect(o.bottom).toBeLessThanOrEqual(s.bottom + 1);
+  expect(o.right).toBeLessThanOrEqual(s.right + 1);
+});
+

--- a/tests/slide-frame-spacing.spec.ts
+++ b/tests/slide-frame-spacing.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+function toFileUrl(p: string) { return 'file://' + path.resolve(p); }
+
+test('Slide frame stays clear of header/footer UI', async ({ page }) => {
+  const appPath = path.resolve(__dirname, '..', 'slider.html');
+  await page.goto(toFileUrl(appPath));
+  await page.waitForSelector('.slide.active');
+
+  const rects = await page.evaluate(() => {
+    const header = document.querySelector('.deck-header') as HTMLElement | null;
+    const footer = document.querySelector('.deck-footer') as HTMLElement | null;
+    const slide = document.querySelector('.slide.active') as HTMLElement | null;
+    if (!header || !footer || !slide) return null;
+    return {
+      header: header.getBoundingClientRect(),
+      footer: footer.getBoundingClientRect(),
+      slide: slide.getBoundingClientRect(),
+    };
+  });
+  expect(rects).not.toBeNull();
+  const { header, footer, slide } = rects! as any;
+  // Allow a small tolerance
+  expect(slide.top).toBeGreaterThan(header.bottom + 4);
+  expect(slide.bottom).toBeLessThan(footer.top - 4);
+});
+


### PR DESCRIPTION
This PR fixes the slide outline/overlay clipping and improves content padding:

- Slide frame fills the full slide region (between header and footer); outline wraps the entire slide
- Content now scrolls inside the frame via a dedicated `.content-scroll` container
- Overlay is rendered above content (`z-index:50`) and no longer sits under markdown
- Padding updated for better vertical rhythm (top 56px, sides 48px, bottom 96px)
- E2E test `overlay-not-clipped.spec.ts` asserts overlay remains visible and within the frame with long content (Chromium/Firefox/WebKit)

Before/After
- Before: Outline and overlay could appear mid-screen; overlay could be clipped/under content on long slides
- After: Outline frames the slide consistently; overlay sits on top; scroll stays inside the frame

Validation
- Lint + Unit: pass
- E2E: existing suite green + new overlay non-clipping test passes in all browsers