### PR TITLE
Fix Playwright config and overlay control state

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "main": "index.js",
   "scripts": {
+    "pretest": "playwright install --with-deps chromium",
     "test": "playwright test --project=chromium",
     "test:chromium": "playwright test --project=chromium",
     "test:ui": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,9 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // Use the full Playwright Chromium build instead of the lightweight
+      // headless shell that can crash in CI environments.
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
     },
     {
       name: 'firefox',

--- a/src/ui/styleModal.js
+++ b/src/ui/styleModal.js
@@ -202,6 +202,8 @@
             w.CONFIG.overlayOn = on;
             setPosDisabled(!on);
             setSizeDisabled(!on);
+            // Subtitle controls follow the overlay on/off state as well
+            setSubtitleControlsDisabled(!on);
             // Rebuild overlays live so the change is visible immediately
             withSafe(()=>{ (w.OverlayCtrl && w.OverlayCtrl.rebuildOverlays) ? w.OverlayCtrl.rebuildOverlays(w.__tempOverlayPos || cur) : (w.rebuildOverlays && w.rebuildOverlays(w.__tempOverlayPos || cur)); });
           };

--- a/src/ui/styleModal.js
+++ b/src/ui/styleModal.js
@@ -177,7 +177,11 @@
         const sc     = document.getElementById('cfgSubtitleColor');
         const setPosDisabled=(d)=>{ [...posWrap.querySelectorAll('button')].forEach(b=>{ if(d){ b.setAttribute('disabled',''); b.setAttribute('aria-disabled','true'); } else { b.removeAttribute('disabled'); b.setAttribute('aria-disabled','false'); } }); if(posHint){ posHint.style.display = d ? 'inline' : 'none'; } };
         const setSizeDisabled=(d)=>{ tSize.disabled = d; };
-        const setSubtitleControlsDisabled=(d)=>{ sSize.disabled = d; cbSub.disabled = d; sc.disabled = d; };
+        // Disable subtitle checkbox only when overlay itself is off, but
+        // keep it enabled when toggling subtitle visibility so users can
+        // re-enable it without re-opening the modal.
+        const setSubtitleOptionsDisabled=(d)=>{ sSize.disabled = d; sc.disabled = d; };
+        const setSubtitleControlsDisabled=(d)=>{ cbSub.disabled = d; setSubtitleOptionsDisabled(d); };
         const cur = ((w.CONFIG?.overlayPos)||'tl').toLowerCase();
         const setActive=(p)=>{ [...posWrap.querySelectorAll('button')].forEach(btn=>{ const on = (btn.dataset.pos===p); btn.classList.toggle('active', on); btn.setAttribute('aria-pressed', on? 'true':'false'); }); };
         setPosDisabled(!(w.CONFIG?.overlayOn===true));
@@ -208,7 +212,7 @@
             withSafe(()=>{ (w.OverlayCtrl && w.OverlayCtrl.rebuildOverlays) ? w.OverlayCtrl.rebuildOverlays(w.__tempOverlayPos || cur) : (w.rebuildOverlays && w.rebuildOverlays(w.__tempOverlayPos || cur)); });
           };
         }
-        cb.onchange = ()=>{ const on = cb.checked; setSubtitleControlsDisabled(!on); w.CONFIG.overlaySubtitleOn = on; withSafe(()=>{ (w.OverlayCtrl && w.OverlayCtrl.rebuildOverlays) ? w.OverlayCtrl.rebuildOverlays(w.__tempOverlayPos || cur) : (w.rebuildOverlays && w.rebuildOverlays(w.__tempOverlayPos || cur)); }); };
+        cb.onchange = ()=>{ const on = cb.checked; setSubtitleOptionsDisabled(!on); w.CONFIG.overlaySubtitleOn = on; withSafe(()=>{ (w.OverlayCtrl && w.OverlayCtrl.rebuildOverlays) ? w.OverlayCtrl.rebuildOverlays(w.__tempOverlayPos || cur) : (w.rebuildOverlays && w.rebuildOverlays(w.__tempOverlayPos || cur)); }); };
         posWrap.querySelectorAll('button').forEach(btn=>{
           btn.setAttribute('aria-pressed', btn.dataset.pos===cur ? 'true' : 'false');
           btn.onclick=()=>{ const pos = btn.dataset.pos; setActive(pos); withSafe(()=>{ w.__tempOverlayPos = pos; }); withSafe(()=>{ w.showToast && w.showToast(`Title position: ${pos.toUpperCase()}`); }); if(w.CONFIG?.overlayOn===true){ withSafe(()=>{ (w.OverlayCtrl && w.OverlayCtrl.rebuildOverlays) ? w.OverlayCtrl.rebuildOverlays(pos) : (w.rebuildOverlays && w.rebuildOverlays(pos)); }); } };


### PR DESCRIPTION
## Summary
- Ensure Playwright uses the full Chromium build to avoid headless shell crashes
- Keep subtitle overlay controls in sync with overlay toggle

## Testing
- `npm test` *(fails: opacity baseline, outline, overlay size tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c689d334008324ad66dc359167d8af